### PR TITLE
Add python 3.7 for worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ For debian7 (php5) images :
 For debian8 (php7) images :
 
     ./build.sh -debian8
+    
+For worker python 3.7 images :
+
+    ./worker/build.sh -python3
 
 
 As of now, those images are intended only to be used as a development environment

--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ For debian8 (php7) images :
     
 For worker python 3.7 images :
 
-    ./worker/build.sh -python3
+    cd worker
+    ./build.sh -python3
 
 
 As of now, those images are intended only to be used as a development environment

--- a/worker/Dockerfile.python3_7
+++ b/worker/Dockerfile.python3_7
@@ -1,0 +1,5 @@
+FROM python:3.7-alpine
+
+RUN apk add --no-cache postgresql-dev gcc musl-dev protobuf netcat-openbsd
+RUN pip install --install-option="--prefix=/install" protobuf==3.1.0.post1
+RUN pip install virtualenv

--- a/worker/build.sh
+++ b/worker/build.sh
@@ -4,7 +4,7 @@ OPTION=$1
 
 if  [[ $OPTION = "-debian8" ]]; then
     docker build -t par-vm232.srv.canaltp.fr:5000/kronos-worker:debian8 -f Dockerfile.debian8 .
-else if [[ $OPTION = "-python3" ]]; then
+elif [[ $OPTION = "-python3" ]]; then
     docker build -t par-vm232.srv.canaltp.fr:5000/kronos-worker:python3_7 -f Dockerfile.python3_7 .
 else
     docker build -t par-vm232.srv.canaltp.fr:5000/kronos-worker .

--- a/worker/build.sh
+++ b/worker/build.sh
@@ -4,7 +4,7 @@ OPTION=$1
 
 if  [[ $OPTION = "-debian8" ]]; then
     docker build -t par-vm232.srv.canaltp.fr:5000/kronos-worker:debian8 -f Dockerfile.debian8 .
-else if [[ $OPTION = "-python3_7" ]]; then
+else if [[ $OPTION = "-python3" ]]; then
     docker build -t par-vm232.srv.canaltp.fr:5000/kronos-worker:python3_7 -f Dockerfile.python3_7 .
 else
     docker build -t par-vm232.srv.canaltp.fr:5000/kronos-worker .

--- a/worker/build.sh
+++ b/worker/build.sh
@@ -4,6 +4,8 @@ OPTION=$1
 
 if  [[ $OPTION = "-debian8" ]]; then
     docker build -t par-vm232.srv.canaltp.fr:5000/kronos-worker:debian8 -f Dockerfile.debian8 .
+else if [[ $OPTION = "-python3_7" ]]; then
+    docker build -t par-vm232.srv.canaltp.fr:5000/kronos-worker:python3_7 -f Dockerfile.python3_7 .
 else
     docker build -t par-vm232.srv.canaltp.fr:5000/kronos-worker .
 fi


### PR DESCRIPTION
related to BOT-1428

you can use the resulted image for development purpose (use on a docker-compose file).

Example : 

```
  persistor:
    image: par-vm232.srv.canaltp.fr:5000/kronos-worker:python3_7
    command: /bin/sh /var/www/Kronos/docker/launch_persistor.sh
    volumes:
      - ~/Kronos:/var/www/Kronos
    links:
      - database
      - rabbitmq
    env_file: ~/Kronos/docker/local.env
```